### PR TITLE
Fix for Swift 4.2

### DIFF
--- a/SwiftMaskText/Source/StringExtensions.swift
+++ b/SwiftMaskText/Source/StringExtensions.swift
@@ -5,6 +5,7 @@
 //  Created by Andre Morais on 3/11/16.
 //  Translated to Swift 3 by: André Santana Ferreira on 31/5/17
 //  Translated to Swift 4 by: André Morais on 04/11/17
+//  Translated tp Swift 4.2 by: Nikita Nikitsky on 05/14/19
 //  Copyright © 2018 Andre Morais. All rights reserved.
 //  Website: http://www.moraisandre.com
 //
@@ -13,12 +14,8 @@ import UIKit
 
 extension String {
 
-    subscript (i: Int) -> Character {
-        return self[self.index(self.startIndex, offsetBy: i)]
-    }
-
     subscript (i: Int) -> String {
-        return String(self[i] as Character)
+        return String(self[self.index(self.startIndex, offsetBy: i)])
     }
 
     subscript (r: Range<Int>) -> String {
@@ -26,4 +23,5 @@ extension String {
         let end = index(start, offsetBy: r.upperBound - r.lowerBound)
         return String(self[(start ..< end)])
     }
+    
 }


### PR DESCRIPTION
- Remove unused subscrion for extension String with return type 'Character'

XCode 10.2
Swift 4.2
Fix error 'Ambiguous Use of Subscript'.